### PR TITLE
Task 1.4: add demo CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ description = "AI-First Coding Assistant (Rust Edition)"
 authors = ["Your Name <your.email@example.com>"]
 
 [dependencies]
+clap = { version = "4.4", features = ["derive"] }
+tokio = { version = "1.37", features = ["macros", "rt-multi-thread"] }
 
 [[bin]]
 name = "project-x"

--- a/src/llm/gemini_client.rs
+++ b/src/llm/gemini_client.rs
@@ -1,0 +1,15 @@
+use std::error::Error;
+
+pub struct GeminiClient;
+
+impl GeminiClient {
+    pub fn new() -> Self {
+        GeminiClient
+    }
+
+    pub async fn generate(&self, prompt: &str) -> Result<String, Box<dyn Error>> {
+        // Placeholder implementation for task 1.4 demo
+        println!("Sending prompt to Gemini: {} (stub)", prompt);
+        Ok("Gemini response".to_string())
+    }
+}

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -1,0 +1,1 @@
+pub mod gemini_client;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,31 @@
-fn main() {
-    println!("Hello, world!");
+use clap::Parser;
+
+mod voice;
+mod llm;
+
+use voice::capture::VoiceRecorder;
+use voice::transcribe::Transcriber;
+use llm::gemini_client::GeminiClient;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about = "Voice to code demo")] 
+struct Args {}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _args = Args::parse();
+
+    let temp_wav = "temp.wav";
+
+    VoiceRecorder::record_audio(temp_wav, 5)?;
+
+    let transcriber = Transcriber::new();
+    let transcript = transcriber.transcribe_audio(temp_wav)?;
+
+    let client = GeminiClient::new();
+    let response = client.generate(&transcript).await?;
+
+    println!("{}", response);
+
+    Ok(())
 }

--- a/src/voice/capture.rs
+++ b/src/voice/capture.rs
@@ -1,0 +1,11 @@
+use std::error::Error;
+
+pub struct VoiceRecorder;
+
+impl VoiceRecorder {
+    pub fn record_audio(output_filename: &str, duration_seconds: u64) -> Result<(), Box<dyn Error>> {
+        // Placeholder implementation for task 1.4 demo
+        println!("Recording audio to {} for {} seconds (stub)", output_filename, duration_seconds);
+        Ok(())
+    }
+}

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -1,0 +1,2 @@
+pub mod capture;
+pub mod transcribe;

--- a/src/voice/transcribe.rs
+++ b/src/voice/transcribe.rs
@@ -1,0 +1,15 @@
+use std::error::Error;
+
+pub struct Transcriber;
+
+impl Transcriber {
+    pub fn new() -> Self {
+        Transcriber
+    }
+
+    pub fn transcribe_audio(&self, input_filename: &str) -> Result<String, Box<dyn Error>> {
+        // Placeholder implementation for task 1.4 demo
+        println!("Transcribing audio from {} (stub)", input_filename);
+        Ok("transcribed text".to_string())
+    }
+}


### PR DESCRIPTION
## Summary
- add Clap and Tokio deps
- implement a stub CLI driving the voice and LLM modules
- create placeholder voice and Gemini modules

## Testing
- `cargo test` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_684c5dd1d8f883219dbe9c0e5892a928